### PR TITLE
Fix optional parameter to SecurityContext setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.6
+
+* Updated the secure networking code to the SDKs version 1.15 SecurityContext api
+
 # 0.9.5+1
 
 * Updated the layout of package contents.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_server
-version: 0.9.6-dev
+version: 0.9.6
 author: Dart Team <misc@dartlang.org>
 description: Library of HTTP server classes.
 homepage: https://www.github.com/dart-lang/http_server

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Library of HTTP server classes.
 homepage: https://www.github.com/dart-lang/http_server
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: '>=1.15.0 <2.0.0'
 dependencies:
   mime: '>=0.9.0 <0.10.0'
   path: '>=0.9.0 <2.0.0'

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -310,5 +310,5 @@ void setupSecure() {
                     password: 'dartdart');
 
   clientContext = new SecurityContext()
-    ..setTrustedCertificates(file: localFile('certificates/trusted_certs.pem'));
+    ..setTrustedCertificates(localFile('certificates/trusted_certs.pem'));
 }


### PR DESCRIPTION
The API of security context changed, and "file" is no longer an optional parameter to .setTrustedCertificates, but mandatory.
