### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.8+2
+
+* Prepare for `File.openRead()` SDK change in signature.
+
 # 0.9.8+1
 
 * Fix a Dart 2 type issue.

--- a/lib/src/virtual_directory.dart
+++ b/lib/src/virtual_directory.dart
@@ -243,6 +243,7 @@ class VirtualDirectory {
               } else {
                 file
                     .openRead(start, end + 1)
+                    .cast<List<int>>()
                     .pipe(_VirtualDirectoryFileStream(response, file.path))
                     .catchError((_) {
                   // TODO(kevmoo): log errors
@@ -259,6 +260,7 @@ class VirtualDirectory {
         } else {
           file
               .openRead()
+              .cast<List<int>>()
               .pipe(_VirtualDirectoryFileStream(response, file.path))
               .catchError((_) {
             // TODO(kevmoo): log errors

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_server
-version: 0.9.8+1
+version: 0.9.8+2
 author: Dart Team <misc@dartlang.org>
 description: Library of HTTP server classes.
 homepage: https://www.github.com/dart-lang/http_server


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

dart-lang/sdk#36900