### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.9.8+3
+
+* Prepare for `HttpClientResponse` SDK change (implements `Stream<Uint8List>`
+  rather than `Stream<List<int>>`).
+
 # 0.9.8+2
 
 * Prepare for `File.openRead()` SDK change in signature.

--- a/lib/src/http_body_impl.dart
+++ b/lib/src/http_body_impl.dart
@@ -88,16 +88,15 @@ class HttpBodyHandlerImpl {
       var charset = contentType.charset;
       if (charset != null) encoding = Encoding.getByName(charset);
       encoding ??= defaultEncoding;
-      return stream
-          .transform(encoding.decoder)
+      return encoding.decoder
+          .bind(stream)
           .fold(StringBuffer(), (buffer, data) => buffer..write(data))
           .then((buffer) => _HttpBody("text", buffer.toString()));
     }
 
     Future<HttpBody> asFormData() {
-      return stream
-          .transform(
-              MimeMultipartTransformer(contentType.parameters['boundary']))
+      return MimeMultipartTransformer(contentType.parameters['boundary'])
+          .bind(stream)
           .map((part) => HttpMultipartFormData.parse(part,
               defaultEncoding: defaultEncoding))
           .map((multipart) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_server
-version: 0.9.8+2
+version: 0.9.8+3
 author: Dart Team <misc@dartlang.org>
 description: Library of HTTP server classes.
 homepage: https://www.github.com/dart-lang/http_server

--- a/test/http_multipart_test.dart
+++ b/test/http_multipart_test.dart
@@ -64,8 +64,8 @@ Future _postDataTest(List<int> message, String contentType, String boundary,
 
   server.listen((request) {
     var boundary = request.headers.contentType.parameters['boundary'];
-    request
-        .transform(MimeMultipartTransformer(boundary))
+    MimeMultipartTransformer(boundary)
+        .bind(request)
         .map((part) =>
             HttpMultipartFormData.parse(part, defaultEncoding: defaultEncoding))
         .map((multipart) {

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -249,7 +249,7 @@ Future<String> _getAsString(int port, String path) {
   return client
       .get('localhost', port, path)
       .then((request) => request.close())
-      .then((response) => utf8.decodeStream(response))
+      .then((response) => utf8.decodeStream(response.cast<List<int>>()))
       .whenComplete(() => client.close());
 }
 


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900