### PR TITLE
Support 7bit, 8bit, binary transfer-encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 0.9.8+4-dev
 
+* Allow multipart form data with specified encodings that don't require
+  decoding.
+
 # 0.9.8+3
 
 * Prepare for `HttpClientResponse` SDK change (implements `Stream<Uint8List>`

--- a/lib/src/http_multipart_form_data_impl.dart
+++ b/lib/src/http_multipart_form_data_impl.dart
@@ -25,12 +25,10 @@ class HttpMultipartFormDataImpl extends Stream
 
   Stream _stream;
 
-  // These `content-transfer-encoding` values indicate that we can handle request data "as-is".
-  static const List<String> _transparentTransferEncodings = [
-    '7bit',
-    '8bit',
-    'binary'
-  ];
+  /// The values which indicate that no incoding was performed.
+  ///
+  /// https://www.w3.org/Protocols/rfc1341/5_Content-Transfer-Encoding.html
+  static const _transparentEncodings = ['7bit', '8bit', 'binary'];
 
   HttpMultipartFormDataImpl(
       this.contentType,
@@ -40,7 +38,7 @@ class HttpMultipartFormDataImpl extends Stream
       Encoding defaultEncoding) {
     _stream = _mimeMultipart;
     if (contentTransferEncoding != null &&
-        !_transparentTransferEncodings
+        !_transparentEncodings
             .contains(contentTransferEncoding.value.toLowerCase())) {
       // TODO(ajohnsen): Support BASE64, etc.
       throw HttpException('Unsupported contentTransferEncoding: '

--- a/lib/src/http_multipart_form_data_impl.dart
+++ b/lib/src/http_multipart_form_data_impl.dart
@@ -24,6 +24,13 @@ class HttpMultipartFormDataImpl extends Stream
 
   Stream _stream;
 
+  // These `content-transfer-encoding` values indicate that we can handle request data "as-is".
+  static const List<String> _transparentTransferEncodings = [
+    '7bit',
+    '8bit',
+    'binary'
+  ];
+
   HttpMultipartFormDataImpl(
       this.contentType,
       this.contentDisposition,
@@ -31,7 +38,9 @@ class HttpMultipartFormDataImpl extends Stream
       this._mimeMultipart,
       Encoding defaultEncoding) {
     _stream = _mimeMultipart;
-    if (contentTransferEncoding != null) {
+    if (contentTransferEncoding != null &&
+        !_transparentTransferEncodings
+            .contains(contentTransferEncoding.value.toLowerCase())) {
       // TODO(ajohnsen): Support BASE64, etc.
       throw HttpException("Unsupported contentTransferEncoding: "
           "${contentTransferEncoding.value}");

--- a/test/http_multipart_test.dart
+++ b/test/http_multipart_test.dart
@@ -133,6 +133,19 @@ Content of file\r
     ]);
   });
 
+  test('With content transfer encoding', () async {
+    var message = '''
+\r\n--AaB03x\r
+Content-Disposition: form-data; name="submit-name"\r
+Content-Transfer-Encoding: 8bit\r
+\r
+Larry\r
+--AaB03x--\r\n''';
+
+    await _postDataTest(message.codeUnits, 'multipart/form-data', 'AaB03x',
+        [FormField('submit-name', 'Larry')]);
+  });
+
   test('Windows/IE style file upload', () async {
     var message = '''
 \r\n--AaB03x\r


### PR DESCRIPTION
While sending `http.MultipartRequest` with both files and fields to a Dart server, I kept getting `Unsupported contentTransferEncoding: binary` errors. I realized that `http_server` doesn't support any values of `transfer-encoding` for multipart parts.

According to [RFC1341](https://www.w3.org/Protocols/rfc1341/5_Content-Transfer-Encoding.html), the `7bit`, `8bit`, and `binary` transfer encodings are effectively transparent, and indicate no specific encoding of content.

This PR just checks if the given transfer encoding is either null, or one of `7bit`, `8bit`, or `binary`.