### PR TITLE
Fix newly enforced `package:pedantic` lints

### DIFF
--- a/lib/src/http_body.dart
+++ b/lib/src/http_body.dart
@@ -125,6 +125,7 @@ class HttpBodyHandler
     return HttpBodyHandlerImpl.processResponse(response, defaultEncoding);
   }
 
+  @override
   Stream<HttpRequestBody> bind(Stream<HttpRequest> stream) {
     return _transformer.bind(stream);
   }

--- a/lib/src/http_body_impl.dart
+++ b/lib/src/http_body_impl.dart
@@ -19,6 +19,7 @@ class HttpBodyHandlerTransformer
 
   const HttpBodyHandlerTransformer(this._defaultEncoding);
 
+  @override
   Stream<HttpRequestBody> bind(Stream<HttpRequest> stream) {
     return Stream<HttpRequestBody>.eventTransformed(
         stream,
@@ -35,6 +36,7 @@ class _HttpBodyHandlerTransformerSink implements EventSink<HttpRequest> {
 
   _HttpBodyHandlerTransformerSink(this._defaultEncoding, this._outSink);
 
+  @override
   void add(HttpRequest request) {
     _pending++;
     HttpBodyHandlerImpl.processRequest(request, _defaultEncoding)
@@ -45,10 +47,12 @@ class _HttpBodyHandlerTransformerSink implements EventSink<HttpRequest> {
     });
   }
 
+  @override
   void addError(Object error, [StackTrace stackTrace]) {
     _outSink.addError(error, stackTrace);
   }
 
+  @override
   void close() {
     _closed = true;
     if (_pending == 0) _outSink.close();
@@ -80,7 +84,7 @@ class HttpBodyHandlerImpl {
     Future<HttpBody> asBinary() {
       return stream
           .fold(BytesBuilder(), (builder, data) => builder..add(data))
-          .then((builder) => _HttpBody("binary", builder.takeBytes()));
+          .then((builder) => _HttpBody('binary', builder.takeBytes()));
     }
 
     Future<HttpBody> asText(Encoding defaultEncoding) {
@@ -91,7 +95,7 @@ class HttpBodyHandlerImpl {
       return encoding.decoder
           .bind(stream)
           .fold(StringBuffer(), (buffer, data) => buffer..write(data))
-          .then((buffer) => _HttpBody("text", buffer.toString()));
+          .then((buffer) => _HttpBody('text', buffer.toString()));
     }
 
     Future<HttpBody> asFormData() {
@@ -136,16 +140,16 @@ class HttpBodyHandlerImpl {
     }
 
     switch (contentType.primaryType) {
-      case "text":
+      case 'text':
         return asText(defaultEncoding);
 
-      case "application":
+      case 'application':
         switch (contentType.subType) {
-          case "json":
+          case 'json':
             return asText(utf8)
-                .then((body) => _HttpBody("json", jsonDecode(body.body)));
+                .then((body) => _HttpBody('json', jsonDecode(body.body)));
 
-          case "x-www-form-urlencoded":
+          case 'x-www-form-urlencoded':
             return asText(ascii).then((body) {
               var map =
                   Uri.splitQueryString(body.body, encoding: defaultEncoding);
@@ -153,7 +157,7 @@ class HttpBodyHandlerImpl {
               for (var key in map.keys) {
                 result[key] = map[key];
               }
-              return _HttpBody("form", result);
+              return _HttpBody('form', result);
             });
 
           default:
@@ -161,9 +165,9 @@ class HttpBodyHandlerImpl {
         }
         break;
 
-      case "multipart":
+      case 'multipart':
         switch (contentType.subType) {
-          case "form-data":
+          case 'form-data':
             return asFormData();
 
           default:
@@ -180,8 +184,11 @@ class HttpBodyHandlerImpl {
 }
 
 class _HttpBodyFileUpload implements HttpBodyFileUpload {
+  @override
   final ContentType contentType;
+  @override
   final String filename;
+  @override
   final dynamic content;
   _HttpBodyFileUpload(this.contentType, this.filename, this.content);
 }

--- a/lib/src/http_body_impl.dart
+++ b/lib/src/http_body_impl.dart
@@ -194,13 +194,16 @@ class _HttpBodyFileUpload implements HttpBodyFileUpload {
 }
 
 class _HttpBody implements HttpBody {
+  @override
   final String type;
+  @override
   final dynamic body;
 
   _HttpBody(this.type, this.body);
 }
 
 class _HttpRequestBody extends _HttpBody implements HttpRequestBody {
+  @override
   final HttpRequest request;
 
   _HttpRequestBody(this.request, HttpBody body) : super(body.type, body.body);
@@ -208,6 +211,7 @@ class _HttpRequestBody extends _HttpBody implements HttpRequestBody {
 
 class _HttpClientResponseBody extends _HttpBody
     implements HttpClientResponseBody {
+  @override
   final HttpClientResponse response;
 
   _HttpClientResponseBody(this.response, HttpBody body)

--- a/lib/src/http_multipart_form_data_impl.dart
+++ b/lib/src/http_multipart_form_data_impl.dart
@@ -14,8 +14,11 @@ import 'http_multipart_form_data.dart';
 
 class HttpMultipartFormDataImpl extends Stream
     implements HttpMultipartFormData {
+  @override
   final ContentType contentType;
+  @override
   final HeaderValue contentDisposition;
+  @override
   final HeaderValue contentTransferEncoding;
 
   final MimeMultipart _mimeMultipart;
@@ -33,8 +36,8 @@ class HttpMultipartFormDataImpl extends Stream
     _stream = _mimeMultipart;
     if (contentTransferEncoding != null) {
       // TODO(ajohnsen): Support BASE64, etc.
-      throw HttpException("Unsupported contentTransferEncoding: "
-          "${contentTransferEncoding.value}");
+      throw HttpException('Unsupported contentTransferEncoding: '
+          '${contentTransferEncoding.value}');
     }
 
     if (contentType == null ||
@@ -50,7 +53,9 @@ class HttpMultipartFormDataImpl extends Stream
     }
   }
 
+  @override
   bool get isText => _isText;
+  @override
   bool get isBinary => !_isText;
 
   static HttpMultipartFormData parse(
@@ -87,8 +92,9 @@ class HttpMultipartFormDataImpl extends Stream
         type, disposition, encoding, multipart, defaultEncoding);
   }
 
-  StreamSubscription listen(void onData(data),
-      {void onDone(), Function onError, bool cancelOnError}) {
+  @override
+  StreamSubscription listen(void Function(dynamic) onData,
+      {void Function() onDone, Function onError, bool cancelOnError}) {
     return _stream.listen(onData,
         onDone: onDone, onError: onError, cancelOnError: cancelOnError);
   }

--- a/lib/src/http_multipart_form_data_impl.dart
+++ b/lib/src/http_multipart_form_data_impl.dart
@@ -99,6 +99,7 @@ class HttpMultipartFormDataImpl extends Stream
         onDone: onDone, onError: onError, cancelOnError: cancelOnError);
   }
 
+  @override
   String value(String name) {
     return _mimeMultipart.headers[name];
   }

--- a/lib/src/virtual_directory.dart
+++ b/lib/src/virtual_directory.dart
@@ -41,7 +41,7 @@ class VirtualDirectory {
 
   final List<String> _pathPrefixSegments;
 
-  final RegExp _invalidPathRegExp = RegExp("[\\\/\x00]");
+  final RegExp _invalidPathRegExp = RegExp('[\\\/\x00]');
 
   _ErrorCallback _errorCallback;
   _DirCallback _dirCallback;
@@ -107,22 +107,22 @@ class VirtualDirectory {
   /// Set the [callback] to override the default directory listing. The
   /// [callback] will be called with the [Directory] to be listed and the
   /// [HttpRequest].
-  set directoryHandler(void callback(Directory dir, HttpRequest request)) {
+  set directoryHandler(void Function(Directory, HttpRequest) callback) {
     _dirCallback = callback;
   }
 
   /// Set the [callback] to override the error page handler. When [callback] is
   /// invoked, the `statusCode` property of the response is set.
-  set errorPageHandler(void callback(HttpRequest request)) {
+  set errorPageHandler(void Function(HttpRequest) callback) {
     _errorCallback = callback;
   }
 
   Future _locateResource(String path, Iterator<String> segments) {
     // Don't allow navigating up paths.
-    if (segments.current == "..") return Future.value(null);
+    if (segments.current == '..') return Future.value(null);
     path = normalize(path);
     // If we jail to root, the relative path can never go up.
-    if (jailRoot && split(path).first == "..") return Future.value(null);
+    if (jailRoot && split(path).first == '..') return Future.value(null);
     String fullPath() => join(root, path);
     return FileSystemEntity.type(fullPath(), followLinks: false).then((type) {
       switch (type) {
@@ -140,7 +140,7 @@ class VirtualDirectory {
             return const _DirectoryRedirect();
           }
           var hasNext = segments.moveNext();
-          if (!hasNext && current == "") {
+          if (!hasNext && current == '') {
             return Directory(dirFullPath());
           } else {
             if (_invalidPathRegExp.hasMatch(current)) break;
@@ -192,13 +192,13 @@ class VirtualDirectory {
       }
 
       response.headers.set(HttpHeaders.lastModifiedHeader, lastModified);
-      response.headers.set(HttpHeaders.acceptRangesHeader, "bytes");
+      response.headers.set(HttpHeaders.acceptRangesHeader, 'bytes');
 
       return file.length().then((length) {
         var range = request.headers.value(HttpHeaders.rangeHeader);
         if (range != null) {
           // We only support one range, where the standard support several.
-          var matches = RegExp(r"^bytes=(\d*)\-(\d*)$").firstMatch(range);
+          var matches = RegExp(r'^bytes=(\d*)\-(\d*)$').firstMatch(range);
           // If the range header have the right format, handle it.
           if (matches != null &&
               (matches[1].isNotEmpty || matches[2].isNotEmpty)) {
@@ -309,7 +309,7 @@ http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
   </tr>
 ''';
       var server = response.headers.value(HttpHeaders.serverHeader);
-      server ??= "";
+      server ??= '';
       var footer = '''</table>
 $server
 </body>
@@ -319,8 +319,8 @@ $server
       response.write(header);
 
       void add(String name, String modified, var size, bool folder) {
-        size ??= "-";
-        modified ??= "";
+        size ??= '-';
+        modified ??= '';
         var encodedSize = const HtmlEscape().convert(size.toString());
         var encodedModified = const HtmlEscape().convert(modified);
         var encodedLink = const HtmlEscape(HtmlEscapeMode.attribute)
@@ -379,7 +379,7 @@ $server
     var encodedError = const HtmlEscape().convert(error.toString());
 
     var server = response.headers.value(HttpHeaders.serverHeader);
-    server ??= "";
+    server ??= '';
     var page = '''<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -403,6 +403,7 @@ class _VirtualDirectoryFileStream extends StreamConsumer<List<int>> {
 
   _VirtualDirectoryFileStream(this.response, this.path);
 
+  @override
   Future addStream(Stream<List<int>> stream) {
     stream.listen((data) {
       if (buffer == null) {

--- a/lib/src/virtual_directory.dart
+++ b/lib/src/virtual_directory.dart
@@ -440,6 +440,7 @@ class _VirtualDirectoryFileStream extends StreamConsumer<List<int>> {
     return response.done;
   }
 
+  @override
   Future close() => Future.value();
 
   void setMimeType(List<int> bytes) {

--- a/lib/src/virtual_host.dart
+++ b/lib/src/virtual_host.dart
@@ -52,6 +52,7 @@ class _VirtualHost implements VirtualHost {
   final _VirtualHostDomain _topDomain = _VirtualHostDomain();
   StreamController<HttpRequest> _unhandledController;
 
+  @override
   Stream<HttpRequest> get unhandled {
     _unhandledController ??= StreamController<HttpRequest>();
 
@@ -62,6 +63,7 @@ class _VirtualHost implements VirtualHost {
     if (source != null) addSource(source);
   }
 
+  @override
   void addSource(Stream<HttpRequest> source) {
     source.listen((request) {
       var host = request.headers.host;
@@ -95,6 +97,7 @@ class _VirtualHost implements VirtualHost {
     });
   }
 
+  @override
   Stream<HttpRequest> addHost(String host) {
     if (host.lastIndexOf('*') > 0) {
       throw ArgumentError(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,5 @@
 name: http_server
-version: 0.9.8+3
-author: Dart Team <misc@dartlang.org>
+version: 0.9.8+4-dev
 description: Library of HTTP server classes.
 homepage: https://www.github.com/dart-lang/http_server
 
@@ -8,8 +7,8 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  mime: '>=0.9.0 <0.10.0'
-  path: '>=0.9.0 <2.0.0'
+  mime: ^0.9.0
+  path: ^1.0.0
 
 dev_dependencies:
   pedantic: ^1.3.0

--- a/test/http_body_test.dart
+++ b/test/http_body_test.dart
@@ -12,7 +12,7 @@ void _testHttpClientResponseBody() {
   void test(
       String mimeType, List<int> content, dynamic expectedBody, String type,
       [bool shouldFail = false]) {
-    HttpServer.bind("localhost", 0).then((server) {
+    HttpServer.bind('localhost', 0).then((server) {
       server.listen((request) {
         request.listen((_) {}, onDone: () {
           request.response.headers.contentType = ContentType.parse(mimeType);
@@ -23,7 +23,7 @@ void _testHttpClientResponseBody() {
 
       var client = HttpClient();
       client
-          .get("localhost", server.port, "/")
+          .get('localhost', server.port, '/')
           .then((request) => request.close())
           .then(HttpBodyHandler.processResponse)
           .then((body) {
@@ -31,13 +31,13 @@ void _testHttpClientResponseBody() {
         expect(body.type, equals(type));
         expect(body.response, isNotNull);
         switch (type) {
-          case "text":
-          case "json":
+          case 'text':
+          case 'json':
             expect(body.body, equals(expectedBody));
             break;
 
           default:
-            fail("bad body type");
+            fail('bad body type');
         }
       }, onError: (error) {
         if (!shouldFail) throw error;
@@ -48,23 +48,23 @@ void _testHttpClientResponseBody() {
     });
   }
 
-  test("text/plain", "body".codeUnits, "body", "text");
-  test("text/plain; charset=utf-8", "body".codeUnits, "body", "text");
-  test("text/plain; charset=iso-8859-1", "body".codeUnits, "body", "text");
-  test("text/plain; charset=us-ascii", "body".codeUnits, "body", "text");
-  test("text/plain; charset=utf-8", [42], "*", "text");
-  test("text/plain; charset=us-ascii", [142], null, "text", true);
-  test("text/plain; charset=utf-8", [142], null, "text", true);
+  test('text/plain', 'body'.codeUnits, 'body', 'text');
+  test('text/plain; charset=utf-8', 'body'.codeUnits, 'body', 'text');
+  test('text/plain; charset=iso-8859-1', 'body'.codeUnits, 'body', 'text');
+  test('text/plain; charset=us-ascii', 'body'.codeUnits, 'body', 'text');
+  test('text/plain; charset=utf-8', [42], '*', 'text');
+  test('text/plain; charset=us-ascii', [142], null, 'text', true);
+  test('text/plain; charset=utf-8', [142], null, 'text', true);
 
-  test("application/json", '{"val": 5}'.codeUnits, {"val": 5}, "json");
-  test("application/json", '{ bad json }'.codeUnits, null, "json", true);
+  test('application/json', '{"val": 5}'.codeUnits, {'val': 5}, 'json');
+  test('application/json', '{ bad json }'.codeUnits, null, 'json', true);
 }
 
 void _testHttpServerRequestBody() {
   void test(
       String mimeType, List<int> content, dynamic expectedBody, String type,
       {bool shouldFail = false, Encoding defaultEncoding = utf8}) {
-    HttpServer.bind("localhost", 0).then((server) {
+    HttpServer.bind('localhost', 0).then((server) {
       server
           .transform(HttpBodyHandler(defaultEncoding: defaultEncoding))
           .listen((body) {
@@ -72,24 +72,24 @@ void _testHttpServerRequestBody() {
         expect(shouldFail, isFalse);
         expect(body.type, equals(type));
         switch (type) {
-          case "text":
+          case 'text':
             expect(body.request.headers.contentType.mimeType,
-                equals("text/plain"));
+                equals('text/plain'));
             expect(body.body, equals(expectedBody));
             break;
 
-          case "json":
+          case 'json':
             expect(body.request.headers.contentType.mimeType,
-                equals("application/json"));
+                equals('application/json'));
             expect(body.body, equals(expectedBody));
             break;
 
-          case "binary":
+          case 'binary':
             expect(body.request.headers.contentType, isNull);
             expect(body.body, equals(expectedBody));
             break;
 
-          case "form":
+          case 'form':
             var mimeType = body.request.headers.contentType.mimeType;
             expect(
                 mimeType,
@@ -111,7 +111,7 @@ void _testHttpServerRequestBody() {
             break;
 
           default:
-            throw StateError("bad body type");
+            throw StateError('bad body type');
         }
         body.request.response.close();
       }, onError: (error) {
@@ -119,7 +119,7 @@ void _testHttpServerRequestBody() {
       });
 
       var client = HttpClient();
-      client.post("localhost", server.port, "/").then((request) {
+      client.post('localhost', server.port, '/').then((request) {
         if (mimeType != null) {
           request.headers.contentType = ContentType.parse(mimeType);
         }
@@ -139,20 +139,20 @@ void _testHttpServerRequestBody() {
     });
   }
 
-  test("text/plain", "body".codeUnits, "body", "text");
-  test("text/plain; charset=utf-8", "body".codeUnits, "body", "text");
-  test("text/plain; charset=utf-8", [42], "*", "text");
-  test("text/plain; charset=us-ascii", [142], null, "text", shouldFail: true);
-  test("text/plain; charset=utf-8", [142], null, "text", shouldFail: true);
+  test('text/plain', 'body'.codeUnits, 'body', 'text');
+  test('text/plain; charset=utf-8', 'body'.codeUnits, 'body', 'text');
+  test('text/plain; charset=utf-8', [42], '*', 'text');
+  test('text/plain; charset=us-ascii', [142], null, 'text', shouldFail: true);
+  test('text/plain; charset=utf-8', [142], null, 'text', shouldFail: true);
 
-  test("application/json", '{"val": 5}'.codeUnits, {"val": 5}, "json");
-  test("application/json", '{ bad json }'.codeUnits, null, "json",
+  test('application/json', '{"val": 5}'.codeUnits, {'val': 5}, 'json');
+  test('application/json', '{ bad json }'.codeUnits, null, 'json',
       shouldFail: true);
 
-  test(null, "body".codeUnits, "body".codeUnits, "binary");
+  test(null, 'body'.codeUnits, 'body'.codeUnits, 'binary');
 
   test(
-      "multipart/form-data; boundary=AaB03x",
+      'multipart/form-data; boundary=AaB03x',
       '''
 --AaB03x\r
 Content-Disposition: form-data; name="name"\r
@@ -160,11 +160,11 @@ Content-Disposition: form-data; name="name"\r
 Larry\r
 --AaB03x--\r\n'''
           .codeUnits,
-      {"name": "Larry"},
-      "form");
+      {'name': 'Larry'},
+      'form');
 
   test(
-      "multipart/form-data; boundary=AaB03x",
+      'multipart/form-data; boundary=AaB03x',
       '''
 --AaB03x\r
 Content-Disposition: form-data; name="files"; filename="myfile"\r
@@ -174,16 +174,16 @@ File content\r
 --AaB03x--\r\n'''
           .codeUnits,
       {
-        "files": {
+        'files': {
           'filename': 'myfile',
           'contentType': 'application/octet-stream',
           'content': 'File content'.codeUnits
         }
       },
-      "form");
+      'form');
 
   test(
-      "multipart/form-data; boundary=AaB03x",
+      'multipart/form-data; boundary=AaB03x',
       '''
 --AaB03x\r
 Content-Disposition: form-data; name="files"; filename="myfile"\r
@@ -198,16 +198,16 @@ File content\r
 --AaB03x--\r\n'''
           .codeUnits,
       {
-        "files": {
+        'files': {
           'filename': 'myfile',
           'contentType': 'text/plain',
           'content': 'File content'
         }
       },
-      "form");
+      'form');
 
   test(
-      "multipart/form-data; boundary=AaB03x",
+      'multipart/form-data; boundary=AaB03x',
       '''
 --AaB03x\r
 Content-Disposition: form-data; name="files"; filename="myfile"\r
@@ -217,13 +217,13 @@ File content\r
 --AaB03x--\r\n'''
           .codeUnits,
       {
-        "files": {
+        'files': {
           'filename': 'myfile',
           'contentType': 'application/json',
           'content': 'File content'
         }
       },
-      "form");
+      'form');
 
   test(
       'application/x-www-form-urlencoded',
@@ -231,61 +231,61 @@ File content\r
               '=%E5%B9%B3%E4%BB%AE%E5%90%8D'
           .codeUnits,
       {'平=仮名': '平仮名', 'b': '平仮名'},
-      "form");
+      'form');
 
   test('application/x-www-form-urlencoded', 'a=%F8+%26%23548%3B'.codeUnits,
-      null, "form",
+      null, 'form',
       shouldFail: true);
 
-  test('application/x-www-form-urlencoded', 'a=%C0%A0'.codeUnits, null, "form",
+  test('application/x-www-form-urlencoded', 'a=%C0%A0'.codeUnits, null, 'form',
       shouldFail: true);
 
-  test('application/x-www-form-urlencoded', 'a=x%A0x'.codeUnits, null, "form",
+  test('application/x-www-form-urlencoded', 'a=x%A0x'.codeUnits, null, 'form',
       shouldFail: true);
 
-  test('application/x-www-form-urlencoded', 'a=x%C0x'.codeUnits, null, "form",
+  test('application/x-www-form-urlencoded', 'a=x%C0x'.codeUnits, null, 'form',
       shouldFail: true);
 
   test('application/x-www-form-urlencoded', 'a=%C3%B8+%C8%A4'.codeUnits,
-      {'a': 'ø Ȥ'}, "form");
+      {'a': 'ø Ȥ'}, 'form');
 
   test('application/x-www-form-urlencoded', 'a=%F8+%26%23548%3B'.codeUnits,
-      {'a': 'ø &#548;'}, "form",
+      {'a': 'ø &#548;'}, 'form',
       defaultEncoding: latin1);
 
   test('application/x-www-form-urlencoded', 'name=%26'.codeUnits, {'name': '&'},
-      "form",
+      'form',
       defaultEncoding: latin1);
 
   test('application/x-www-form-urlencoded', 'name=%F8%26'.codeUnits,
-      {'name': 'ø&'}, "form",
+      {'name': 'ø&'}, 'form',
       defaultEncoding: latin1);
 
   test('application/x-www-form-urlencoded', 'name=%26%3B'.codeUnits,
-      {'name': '&;'}, "form",
+      {'name': '&;'}, 'form',
       defaultEncoding: latin1);
 
   test(
       'application/x-www-form-urlencoded',
       'name=%26%23548%3B%26%23548%3B'.codeUnits,
       {'name': '&#548;&#548;'},
-      "form",
+      'form',
       defaultEncoding: latin1);
 
   test('application/x-www-form-urlencoded', 'name=%26'.codeUnits, {'name': '&'},
-      "form");
+      'form');
 
   test('application/x-www-form-urlencoded', 'name=%C3%B8%26'.codeUnits,
-      {'name': 'ø&'}, "form");
+      {'name': 'ø&'}, 'form');
 
   test('application/x-www-form-urlencoded', 'name=%26%3B'.codeUnits,
-      {'name': '&;'}, "form");
+      {'name': '&;'}, 'form');
 
   test('application/x-www-form-urlencoded', 'name=%C8%A4%26%23548%3B'.codeUnits,
-      {'name': 'Ȥ&#548;'}, "form");
+      {'name': 'Ȥ&#548;'}, 'form');
 
   test('application/x-www-form-urlencoded', 'name=%C8%A4%C8%A4'.codeUnits,
-      {'name': 'ȤȤ'}, "form");
+      {'name': 'ȤȤ'}, 'form');
 }
 
 void main() {

--- a/test/http_mock.dart
+++ b/test/http_mock.dart
@@ -8,11 +8,14 @@ import 'dart:io';
 class MockHttpHeaders implements HttpHeaders {
   final Map<String, List<String>> _headers = HashMap<String, List<String>>();
 
-  operator [](key) => _headers[key];
+  @override
+  List<String> operator [](key) => _headers[key];
 
+  @override
   int get contentLength =>
       int.parse(_headers[HttpHeaders.contentLengthHeader][0]);
 
+  @override
   DateTime get ifModifiedSince {
     var values = _headers[HttpHeaders.ifModifiedSinceHeader];
     if (values != null) {
@@ -25,20 +28,24 @@ class MockHttpHeaders implements HttpHeaders {
     return null;
   }
 
+  @override
   set ifModifiedSince(DateTime ifModifiedSince) {
     // Format "ifModifiedSince" header with date in Greenwich Mean Time (GMT).
     var formatted = HttpDate.format(ifModifiedSince.toUtc());
     _set(HttpHeaders.ifModifiedSinceHeader, formatted);
   }
 
+  @override
   ContentType contentType;
 
+  @override
   void set(String name, Object value) {
     name = name.toLowerCase();
     _headers.remove(name);
     _addAll(name, value);
   }
 
+  @override
   String value(String name) {
     name = name.toLowerCase();
     var values = _headers[name];
@@ -49,6 +56,7 @@ class MockHttpHeaders implements HttpHeaders {
     return values[0];
   }
 
+  @override
   String toString() => '$runtimeType : $_headers';
 
   // [name] must be a lower-case version of the name.
@@ -99,6 +107,7 @@ class MockHttpHeaders implements HttpHeaders {
   /*
    * Implemented to remove editor warnings
    */
+  @override
   dynamic noSuchMethod(Invocation invocation) {
     print([
       invocation.memberName,
@@ -112,9 +121,13 @@ class MockHttpHeaders implements HttpHeaders {
 }
 
 class MockHttpRequest implements HttpRequest {
+  @override
   final Uri uri;
+  @override
   final MockHttpResponse response = MockHttpResponse();
+  @override
   final HttpHeaders headers = MockHttpHeaders();
+  @override
   final String method = 'GET';
   final bool followRedirects;
 
@@ -128,6 +141,7 @@ class MockHttpRequest implements HttpRequest {
   /*
    * Implemented to remove editor warnings
    */
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 

--- a/test/http_mock.dart
+++ b/test/http_mock.dart
@@ -51,7 +51,7 @@ class MockHttpHeaders implements HttpHeaders {
     var values = _headers[name];
     if (values == null) return null;
     if (values.length > 1) {
-      throw HttpException("More than one value for header $name");
+      throw HttpException('More than one value for header $name');
     }
     return values[0];
   }
@@ -67,7 +67,7 @@ class MockHttpHeaders implements HttpHeaders {
       } else if (value is String) {
         _set(HttpHeaders.ifModifiedSinceHeader, value);
       } else {
-        throw HttpException("Unexpected type for header named $name");
+        throw HttpException('Unexpected type for header named $name');
       }
     } else {
       _addValue(name, value);
@@ -146,6 +146,7 @@ class MockHttpRequest implements HttpRequest {
 }
 
 class MockHttpResponse implements HttpResponse {
+  @override
   final HttpHeaders headers = MockHttpHeaders();
   final Completer _completer = Completer();
   final List<int> _buffer = <int>[];
@@ -161,35 +162,44 @@ class MockHttpResponse implements HttpResponse {
 
   bool _isDone = false;
 
+  @override
   int statusCode = HttpStatus.ok;
 
+  @override
   String get reasonPhrase => _findReasonPhrase(statusCode);
 
+  @override
   set reasonPhrase(String value) {
     _reasonPhrase = value;
   }
 
+  @override
   Future get done => _doneFuture;
 
+  @override
   Future close() {
     _completer.complete();
     return _doneFuture;
   }
 
+  @override
   void add(List<int> data) {
     _buffer.addAll(data);
   }
 
+  @override
   void addError(error, [StackTrace stackTrace]) {
     // doesn't seem to be hit...hmm...
   }
 
+  @override
   Future redirect(Uri location, {int status = HttpStatus.movedTemporarily}) {
     statusCode = status;
     headers.set(HttpHeaders.locationHeader, location.toString());
     return close();
   }
 
+  @override
   void write(Object obj) {
     var str = obj.toString();
     add(utf8.encode(str));
@@ -198,6 +208,7 @@ class MockHttpResponse implements HttpResponse {
   /*
    * Implemented to remove editor warnings
    */
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 
   String get mockContent => utf8.decode(_buffer);
@@ -215,9 +226,9 @@ class MockHttpResponse implements HttpResponse {
 
     switch (statusCode) {
       case HttpStatus.notFound:
-        return "Not Found";
+        return 'Not Found';
       default:
-        return "Status $statusCode";
+        return 'Status $statusCode';
     }
   }
 }

--- a/test/http_multipart_test.dart
+++ b/test/http_multipart_test.dart
@@ -6,9 +6,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import "package:http_server/http_server.dart";
-import "package:mime/mime.dart";
-import "package:test/test.dart";
+import 'package:http_server/http_server.dart';
+import 'package:mime/mime.dart';
+import 'package:test/test.dart';
 
 // Representation of a form field from a multipart/form-data form POST body.
 class FormField {
@@ -24,6 +24,7 @@ class FormField {
 
   FormField(this.name, this.value, {this.contentType, this.filename});
 
+  @override
   bool operator ==(other) =>
       other is FormField &&
       _valuesEqual(value, other.value) &&
@@ -31,8 +32,10 @@ class FormField {
       contentType == other.contentType &&
       filename == other.filename;
 
+  @override
   int get hashCode => name.hashCode;
 
+  @override
   String toString() {
     return "FormField('$name', '$value', '$contentType', '$filename')";
   }
@@ -58,7 +61,7 @@ class FormField {
 Future _postDataTest(List<int> message, String contentType, String boundary,
     List<FormField> expectedFields,
     {Encoding defaultEncoding = latin1}) async {
-  var addr = (await InternetAddress.lookup("localhost"))[0];
+  var addr = (await InternetAddress.lookup('localhost'))[0];
 
   var server = await HttpServer.bind(addr, 0);
 

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -9,7 +9,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:mirrors';
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
 import 'package:http_server/http_server.dart';
@@ -24,12 +24,13 @@ SecurityContext clientContext;
 ///  Used to flag a given test case as being a mock or not.
 final _isMockTestExpando = Expando<bool>('isMockTest');
 
-void testVirtualDir(String name, Future func(Directory dir)) {
+void testVirtualDir(String name, Future<void> Function(Directory) func) {
   _testVirtualDir(name, false, func);
   _testVirtualDir(name, true, func);
 }
 
-void _testVirtualDir(String name, bool useMocks, Future func(Directory dir)) {
+void _testVirtualDir(
+    String name, bool useMocks, Future<void> Function(Directory) func) {
   if (useMocks) {
     name = '$name, with mocks';
   }
@@ -221,7 +222,7 @@ Future<MockHttpResponse> _withMockRequest(
 }
 
 Future<T> _withServer<T>(
-    VirtualDirectory virDir, Future<T> func(int port)) async {
+    VirtualDirectory virDir, Future<T> Function(int port) func) async {
   var server = await HttpServer.bind('localhost', 0);
 
   try {

--- a/test/virtual_directory_test.dart
+++ b/test/virtual_directory_test.dart
@@ -5,9 +5,9 @@
 import 'dart:async';
 import 'dart:io';
 
-import "package:http_server/http_server.dart";
+import 'package:http_server/http_server.dart';
 import 'package:path/path.dart' as pathos;
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 import 'utils.dart';
 

--- a/test/virtual_host_test.dart
+++ b/test/virtual_host_test.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 import 'dart:io';
 
-import "package:test/test.dart";
-import "package:http_server/http_server.dart";
+import 'package:test/test.dart';
+import 'package:http_server/http_server.dart';
 
 import 'utils.dart';
 


### PR DESCRIPTION
- always_declare_return_types
- annotate_overrides
- prefer_single_quotes
- use_function_type_syntax_for_parameters

Remove unused author field from pubspec.

Use the simpler caret notation for dependencies. Bump minimum version of
`package:path` to `1.0.0` since Dart 2 was not supported on earlier
versions anyway so they won't be picked up by version solving.