### PR TITLE
add preserveHeaderCase argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 0.10.0
 
-* Preparation for [HttpHeaders change]. Update signature of `add()`
-  and `set()` to match new signature of `HttpHeaders`. The
-  parameter is not yet forwarded and will not behave as expected.
+* Preparation for [HttpHeaders change]. Update signature of `set()` to match
+  new signature of `HttpHeaders`. The parameter is not yet forwarded and
+  will not behave as expected.
 
   [HttpHeaders change]: https://github.com/dart-lang/sdk/issues/39657
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.10.0
+
+* Preparation for [HttpHeaders change]. Update signature of `add()`
+  and `set()` to match new signature of `HttpHeaders`. The
+  parameter is not yet forwarded and will not behave as expected.
+
+  [HttpHeaders change]: https://github.com/dart-lang/sdk/issues/39657
+
 # 0.9.8+3
 
 * Prepare for `HttpClientResponse` SDK change (implements `Stream<Uint8List>`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_server
-version: 0.9.8+4-dev
+version: 0.10.0
 description: Library of HTTP server classes.
 homepage: https://www.github.com/dart-lang/http_server
 

--- a/test/http_mock.dart
+++ b/test/http_mock.dart
@@ -41,7 +41,7 @@ class MockHttpHeaders implements HttpHeaders {
 
   @override
   void set(String name, Object value, {bool preserveHeaderCase = false}) {
-    // The name is determined by the lastest `set` call.
+    // The casing of Header name is determined by the latest `set` call.
     if (preserveHeaderCase) {
       _originalHeaderName[name.toLowerCase()] = name;
     } else {

--- a/test/http_mock.dart
+++ b/test/http_mock.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 class MockHttpHeaders implements HttpHeaders {
   final Map<String, List<String>> _headers = HashMap<String, List<String>>();
+  final Map<String, String> _originalHeaderName = HashMap<String, String>();
 
   @override
   List<String> operator [](key) => _headers[key];
@@ -39,8 +40,14 @@ class MockHttpHeaders implements HttpHeaders {
   ContentType contentType;
 
   @override
-  void set(String name, Object value) {
-    name = name.toLowerCase();
+  void set(String name, Object value, {bool preserveHeaderCase = false}) {
+    // The name is determined by the lastest `set` call.
+    if (preserveHeaderCase) {
+      _originalHeaderName[name.toLowerCase()] = name;
+    } else {
+      name = name.toLowerCase();
+      _originalHeaderName[name] = name;
+    }
     _headers.remove(name);
     _addAll(name, value);
   }
@@ -57,7 +64,11 @@ class MockHttpHeaders implements HttpHeaders {
   }
 
   @override
-  String toString() => '$runtimeType : $_headers';
+  String toString() {
+    var map = {};
+    _headers.forEach((k,v) => map[_originalHeaderName[k]] = v);
+    return '$runtimeType : $map';
+  }
 
   // [name] must be a lower-case version of the name.
   void _add(String name, value) {


### PR DESCRIPTION
An upcoming SDK release will add a named argument which must be included for any class which `implements` the interface. Pre-emptively add the argument to the signature so that we have a version of this package which is forward compatible with the SDK. We will properly forward the argument once we have an SDK release with the change.

https://github.com/dart-lang/sdk/issues/39657