### PR TITLE
Add preserveHeaderCase argument in test util

### DIFF
--- a/test/http_mock.dart
+++ b/test/http_mock.dart
@@ -39,7 +39,10 @@ class MockHttpHeaders implements HttpHeaders {
   ContentType contentType;
 
   @override
-  void set(String name, Object value) {
+  void set(String name, Object value, {bool preserveHeaderCase = false}) {
+    if (preserveHeaderCase) {
+      throw ArgumentError('preserveHeaderCase not supported');
+    }
     name = name.toLowerCase();
     _headers.remove(name);
     _addAll(name, value);


### PR DESCRIPTION
This will be forwards compatible with the version of the SDK that adds
this argument.