### PR TITLE
Modernize doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.9.8+4-dev
+
 # 0.9.8+3
 
 * Prepare for `HttpClientResponse` SDK change (implements `Stream<Uint8List>`

--- a/lib/http_server.dart
+++ b/lib/http_server.dart
@@ -2,25 +2,25 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Here is a short example of how to serve all files from the current
-/// directory.
+/// Utilities for working with `HttpServer`.
 ///
-/// 	import 'dart:io';
-/// 	import 'dart:async';
-/// 	import 'package:http_server/http_server.dart';
+/// ## Example
 ///
-/// 	void main() {
-/// 	  var staticFiles = new VirtualDirectory('.')
-/// 	    ..allowDirectoryListing = true;
+/// Serving all files from the current directory.
 ///
-/// 	  runZoned(() {
-/// 	    HttpServer.bind('0.0.0.0', 7777).then((server) {
-/// 	      print('Server running');
-/// 	      server.listen(staticFiles.serveRequest);
-/// 	    });
-/// 	  },
-/// 	  onError: (e, stackTrace) => print('Oh noes! $e $stackTrace'));
-///     }
+/// ```dart
+/// import 'dart:io';
+///
+/// import 'package:http_server/http_server.dart';
+///
+/// Future<void> serveCurrentDirectory() async {
+///   var staticFiles = VirtualDirectory('.')..allowDirectoryListing = true;
+///
+///   var server = await HttpServer.bind('0.0.0.0', 7777);
+///   print('Server running');
+///   server.listen(staticFiles.serveRequest);
+/// }
+/// ```
 ///
 /// ## Virtual directory
 ///
@@ -42,13 +42,15 @@
 /// address, by using the `Host` field of the incoming requests. It also
 /// works with wildcards for sub-domains.
 ///
-///     var virtualHost = new VirtualHost(server);
-///     // Filter out on a specific host
-///     var stream1 = virtualServer.addHost('static.myserver.com');
-///     // Wildcard for any other sub-domains.
-///     var stream2 = virtualServer.addHost('*.myserver.com');
-///     // Requests not matching any hosts.
-///     var stream3 = virtualServer.unhandled;
+/// ```dart
+/// var virtualHost = new VirtualHost(server);
+/// // Filter out on a specific host
+/// var stream1 = virtualServer.addHost('static.myserver.com');
+/// // Wildcard for any other sub-domains.
+/// var stream2 = virtualServer.addHost('*.myserver.com');
+/// // Requests not matching any hosts.
+/// var stream3 = virtualServer.unhandled;
+/// ```
 ///
 /// See [VirtualHost] for more information.
 library http_server;

--- a/lib/src/http_body.dart
+++ b/lib/src/http_body.dart
@@ -2,97 +2,98 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http_server.http_body;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
 import 'http_body_impl.dart';
 
-/// [HttpBodyHandler] is a helper class for processing and collecting
-/// HTTP message data in an easy-to-use [HttpBody] object. The content
-/// body is parsed, depending on the `Content-Type` header field. When
-/// the full body is read and parsed the body content is made
-/// available. The class can be used to process both server requests
-/// and client responses.
+/// A handler for processing and collecting HTTP message data in to an
+/// [HttpBody].
+///
+/// The content body is parsed, depending on the `Content-Type` header field.
+/// When the full body is read and parsed the body content is made available.
+/// The class can be used to process both server requests and client responses.
 ///
 /// The following content types are recognized:
 ///
-///     text/ *
-///     application/json
-///     application/x-www-form-urlencoded
-///     multipart/form-data
+/// - text/*
+/// - application/json
+/// - application/x-www-form-urlencoded
+/// - multipart/form-data
 ///
-///  For content type `text/\*` the body is decoded into a string. The
-///  'charset' parameter of the content type specifies the encoding
-///  used for decoding. If no 'charset' is present the default encoding
-///  of ISO-8859-1 is used.
+/// For content type `text/*` the body is decoded into a string. The
+/// 'charset' parameter of the content type specifies the encoding
+/// used for decoding. If no 'charset' is present the default encoding
+/// of ISO-8859-1 is used.
 ///
-///  For content type `application/json` the body is decoded into a
-///  string which is then parsed as JSON. The resulting body is a
-///  [Map].  The 'charset' parameter of the content type specifies the
-///  encoding used for decoding. If no 'charset' is present the default
-///  encoding of UTF-8 is used.
+/// For content type `application/json` the body is decoded into a
+/// string which is then parsed as JSON. The resulting body is a
+/// [Map].  The 'charset' parameter of the content type specifies the
+/// encoding used for decoding. If no 'charset' is present the default
+/// encoding of UTF-8 is used.
 ///
-///  For content type `application/x-www-form-urlencoded` the body is a
-///  query string which is then split according to the rules for
-///  splitting a query string. The resulting body is a `Map<String,
-///  String>`.  If the same name is present several times in the query
-///  string, then the last value seen for this name will be in the
-///  resulting map. The encoding US-ASCII is always used for decoding
-///  the body.
+/// For content type `application/x-www-form-urlencoded` the body is a
+/// query string which is then split according to the rules for
+/// splitting a query string. The resulting body is a `Map<String,
+/// String>`.  If the same name is present several times in the query
+/// string, then the last value seen for this name will be in the
+/// resulting map. The encoding US-ASCII is always used for decoding
+/// the body.
 ///
-///  For content type `multipart/form-data` the body is parsed into
-///  it's different fields. The resulting body is a `Map<String,
-///  dynamic>`, where the value is a [String] for normal fields and a
-///  [HttpBodyFileUpload] instance for file upload fields. If the same
-///  name is present several times, then the last value seen for this
-///  name will be in the resulting map.
+/// For content type `multipart/form-data` the body is parsed into
+/// it's different fields. The resulting body is a `Map<String,
+/// dynamic>`, where the value is a [String] for normal fields and a
+/// [HttpBodyFileUpload] instance for file upload fields. If the same
+/// name is present several times, then the last value seen for this
+/// name will be in the resulting map.
 ///
-///  When using content type `multipart/form-data` the encoding of
-///  fields with [String] values is determined by the browser sending
-///  the HTTP request with the form data. The encoding is specified
-///  either by the attribute `accept-charset` on the HTML form, or by
-///  the content type of the web page containing the form. If the HTML
-///  form has an `accept-charset` attribute the browser will use the
-///  encoding specified there. If the HTML form has no `accept-charset`
-///  attribute the browser determines the encoding from the content
-///  type of the web page containing the form. Using a content type of
-///  `text/html; charset=utf-8` for the page and setting
-///  `accept-charset` on the HTML form to `utf-8` is recommended as the
-///  default for [HttpBodyHandler] is UTF-8. It is important to get
-///  these encoding values right, as the actual `multipart/form-data`
-///  HTTP request sent by the browser does _not_ contain any
-///  information on the encoding. If something else than UTF-8 is used
-///  `defaultEncoding` needs to be set in the [HttpBodyHandler]
-///  constructor and calls to [processRequest] and [processResponse].
+/// When using content type `multipart/form-data` the encoding of
+/// fields with [String] values is determined by the browser sending
+/// the HTTP request with the form data. The encoding is specified
+/// either by the attribute `accept-charset` on the HTML form, or by
+/// the content type of the web page containing the form. If the HTML
+/// form has an `accept-charset` attribute the browser will use the
+/// encoding specified there. If the HTML form has no `accept-charset`
+/// attribute the browser determines the encoding from the content
+/// type of the web page containing the form. Using a content type of
+/// `text/html; charset=utf-8` for the page and setting
+/// `accept-charset` on the HTML form to `utf-8` is recommended as the
+/// default for [HttpBodyHandler] is UTF-8. It is important to get
+/// these encoding values right, as the actual `multipart/form-data`
+/// HTTP request sent by the browser does _not_ contain any
+/// information on the encoding. If something else than UTF-8 is used
+/// `defaultEncoding` needs to be set in the [HttpBodyHandler]
+/// constructor and calls to [processRequest] and [processResponse].
 ///
-///  For all other content types the body will be treated as
-///  uninterpreted binary data. The resulting body will be of type
-///  `List<int>`.
+/// For all other content types the body will be treated as
+/// uninterpreted binary data. The resulting body will be of type
+/// `List<int>`.
 ///
 /// To use with the [HttpServer] for request messages, [HttpBodyHandler] can be
 /// used as either a [StreamTransformer] or as a per-request handler (see
 /// [processRequest]).
 ///
-///     HttpServer server = ...
-///     server.transform(new HttpBodyHandler())
-///         .listen((HttpRequestBody body) {
-///           ...
-///         });
+/// ```dart
+/// HttpServer server = ...
+/// server.transform(HttpBodyHandler())
+///     .listen((HttpRequestBody body) {
+///       ...
+///     });
+/// ```
 ///
 /// To use with the [HttpClient] for response messages, [HttpBodyHandler] can be
 /// used as a per-request handler (see [processResponse]).
 ///
-///     HttpClient client = ...
-///     client.get(...)
-///         .then((HttpClientRequest response) => response.close())
-///         .then(HttpBodyHandler.processResponse)
-///         .then((HttpClientResponseBody body) {
-///           ...
-///         });
-///
+/// ```dart
+/// HttpClient client = ...
+/// client.get(...)
+///     .then((HttpClientRequest response) => response.close())
+///     .then(HttpBodyHandler.processResponse)
+///     .then((HttpClientResponseBody body) {
+///       ...
+///     });
+/// ```
 class HttpBodyHandler
     extends StreamTransformerBase<HttpRequest, HttpRequestBody> {
   final HttpBodyHandlerTransformer _transformer;
@@ -107,10 +108,12 @@ class HttpBodyHandler
   HttpBodyHandler({Encoding defaultEncoding = utf8})
       : _transformer = HttpBodyHandlerTransformer(defaultEncoding);
 
-  /// Process and parse an incoming [HttpRequest]. The returned [HttpRequestBody]
-  /// contains a `response` field for accessing the [HttpResponse].
+  /// Process and parse an incoming [HttpRequest].
   ///
-  /// See [HttpBodyHandler] constructor for more info on [defaultEncoding].
+  /// The returned [HttpRequestBody] contains a `response` field for accessing
+  /// the [HttpResponse].
+  ///
+  /// See [new HttpBodyHandler] for more info on [defaultEncoding].
   static Future<HttpRequestBody> processRequest(HttpRequest request,
       {Encoding defaultEncoding = utf8}) {
     return HttpBodyHandlerImpl.processRequest(request, defaultEncoding);
@@ -118,7 +121,7 @@ class HttpBodyHandler
 
   /// Process and parse an incoming [HttpClientResponse].
   ///
-  /// See [HttpBodyHandler] constructor for more info on [defaultEncoding].
+  /// See [new HttpBodyHandler] for more info on [defaultEncoding].
   static Future<HttpClientResponseBody> processResponse(
       HttpClientResponse response,
       {Encoding defaultEncoding = utf8}) {
@@ -138,40 +141,41 @@ abstract class HttpBody {
   /// "text", "binary" and "json".
   String get type;
 
-  /// The actual body. The type depends on [type].
+  /// The content of the body with a type depending on [type].
   dynamic get body;
 }
 
-/// The [HttpBody] of a [HttpClientResponse] will be of type
-/// [HttpClientResponseBody]. It contains the [HttpClientResponse] object
-/// for access to the headers.
+/// The body of a [HttpClientResponse].
+///
+/// Headers can be read through the original [response].
 abstract class HttpClientResponseBody extends HttpBody {
-  /// The [HttpClientResponse] from which the [HttpClientResponseBody] was
-  /// created.
+  /// The wrapped response.
   HttpClientResponse get response;
 }
 
-/// The [HttpBody] of a [HttpRequest] will be of type [HttpRequestBody]. It
-/// provides access to the request, for reading all request header information
-/// and responding to the client.
+/// The body of a [HttpRequest].
+///
+/// Headers can be read, and a response can be sent, through [request].
 abstract class HttpRequestBody extends HttpBody {
-  /// The [HttpRequest] from which the [HttpRequestBody] was created.
+  /// The wrapped request.
   ///
-  /// Note that the [HttpRequest] is already drained at this point, so the
+  /// Note that the [HttpRequest] is already drained, so the
   /// `Stream` methods cannot be used.
   HttpRequest get request;
 }
 
-/// A [HttpBodyFileUpload] object wraps a file upload, presenting a way for
-/// extracting filename, contentType and the data of the uploaded file.
+/// A wrapper around a file upload.
 abstract class HttpBodyFileUpload {
   /// The filename of the uploaded file.
   String get filename;
 
-  /// The [ContentType] of the uploaded file. For 'text/\*' and
-  /// 'application/json' the [content] field will a String.
+  /// The [ContentType] of the uploaded file.
+  ///
+  /// For `text/*` and `application/json` the [content] field will a String.
   ContentType get contentType;
 
-  /// The content of the file. Either a [String] or a [List<int>].
+  /// The content of the file.
+  ///
+  /// Either a [String] or a [List<int>].
   dynamic get content;
 }

--- a/lib/src/http_body_impl.dart
+++ b/lib/src/http_body_impl.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http_server.http_body_impl;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/lib/src/http_multipart_form_data.dart
+++ b/lib/src/http_multipart_form_data.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http_server.http_multipart_form_data;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -12,55 +10,62 @@ import 'package:mime/mime.dart';
 
 import 'http_multipart_form_data_impl.dart';
 
-/// [:HttpMultipartFormData:] class used for 'upgrading' a [MimeMultipart] by
-/// parsing it as a 'multipart/form-data' part. The following code shows how
-/// it can be used.
+/// The data in a `multipart/form-data` part.
 ///
-///   HttpServer server = ...;
-///   server.listen((request) {
-///     String boundary = request.headers.contentType.parameters['boundary'];
-///     request
-///         .transform(new MimeMultipartTransformer(boundary))
-///         .map(HttpMultipartFormData.parse)
-///         .map((HttpMultipartFormData formData) {
-///           // form data object available here.
-///         });
+/// ## Example
 ///
-/// [:HttpMultipartFormData:] is a Stream, serving either bytes or decoded
+/// ```dart
+/// HttpServer server = ...;
+/// server.listen((request) {
+///   var boundary = request.headers.contentType.parameters['boundary'];
+///   request
+///       .transform(MimeMultipartTransformer(boundary))
+///       .map(HttpMultipartFormData.parse)
+///       .map((HttpMultipartFormData formData) {
+///         // form data object available here.
+///       });
+/// ```
+///
+/// [HttpMultipartFormData] is a Stream, serving either bytes or decoded
 /// Strings. Use [isText] or [isBinary] to see what type of data is provided.
 abstract class HttpMultipartFormData implements Stream {
-  /// The parsed [:Content-Type:] header of the [:HttpMultipartFormData:].
-  /// Returns [:null:] if not present.
+  /// The parsed `Content-Type` header value.
+  ///
+  /// Returns `null` if not present.
   ContentType get contentType;
 
-  /// The parsed [:Content-Disposition:] header of the [:HttpMultipartFormData:].
-  /// This field is always present. Use this to extract e.g. name(form field
-  /// name)and filename (client provided name of uploaded file) parameters.
+  /// The parsed `Content-Disposition` header value.
+  ///
+  /// This field is always present. Use this to extract e.g. name (form field
+  /// name) and filename (client provided name of uploaded file) parameters.
   HeaderValue get contentDisposition;
 
-  /// The parsed [:Content-Transfer-Encoding:] header of the
-  /// [:HttpMultipartFormData:]. This field is used to determine how to decode
-  /// the data. Returns [:null:] if not present.
+  /// The parsed `Content-Transfer-Encoding` header value.
+  ///
+  /// This field is used to determine how to decode the data. Returns `null`
+  /// if not present.
   HeaderValue get contentTransferEncoding;
 
-  /// Returns [:true:] if the data is decoded as [String].
+  /// Whether the data is decoded as [String].
   bool get isText;
 
-  /// Returns [:true:] if the data is raw bytes.
+  /// Whether the data is raw bytes.
   bool get isBinary;
 
-  /// Returns the value for the header named [name]. If there
-  /// is no header with the provided name, [:null:] will be returned.
+  /// Returns the value for the header named [name].
+  ///
+  /// If there is no header with the provided name, `null` will be returned.
   ///
   /// Use this method to index other headers available in the original
   /// [MimeMultipart].
   String value(String name);
 
-  /// Parse a [MimeMultipart] and return a [HttpMultipartFormData]. If the
-  /// [:Content-Disposition:] header is missing or invalid, a [HttpException] is
-  /// thrown.
+  /// Parse a [MimeMultipart] and return a [HttpMultipartFormData].
   ///
-  /// If the [MimeMultipart] is identified as text, and the [:Content-Type:]
+  /// If the `Content-Disposition` header is missing or invalid, an
+  /// [HttpException] is thrown.
+  ///
+  /// If the [MimeMultipart] is identified as text, and the `Content-Type`
   /// header is missing, the data is decoded using [defaultEncoding]. See more
   /// information in the
   /// [HTML5 spec](http://dev.w3.org/html5/spec-preview/

--- a/lib/src/http_multipart_form_data_impl.dart
+++ b/lib/src/http_multipart_form_data_impl.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http_server.http_multipart_form_data_impl;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/lib/src/virtual_host.dart
+++ b/lib/src/virtual_host.dart
@@ -2,40 +2,41 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http_server.virtual_host;
-
 import 'dart:async';
 import 'dart:io';
 
-/// The [VirtualHost] class is a utility class for handling multiple hosts on
-/// multiple sources, by using a named-based approach.
+/// A utility for handling multiple hosts on multiple sources using a
+/// named-based approach.
 abstract class VirtualHost {
-  /// Get the [Stream] of [HttpRequest]s, not matching any hosts. If unused, the
-  /// default implementation will result in a [HttpStatus.forbidden] response.
+  /// The [Stream] of [HttpRequest] not matching any hosts.
+  ///
+  /// If this field is not read the default implementation will result in a
+  /// [HttpStatus.forbidden] response.
   Stream<HttpRequest> get unhandled;
 
-  /// Construct a new [VirtualHost].
+  /// Construct an [VirtualHost] with an optional initial source.
   ///
   /// The optional [source] is a shortcut for calling [addSource].
   ///
-  /// Example of usage:
+  /// ## Example
   ///
-  ///   HttpServer.bind(..., 80).then((server) {
-  ///     var virtualHost = new VirtualHost(server);
-  ///     virtualServer.addHost('static.myserver.com')
-  ///         .listen(...);
-  ///     virtualServer.addHost('cache.myserver.com')
-  ///         .listen(...);
-  ///   })
+  /// ```dart
+  /// var server = await HttpServer.bind(..., 80);
+  /// var virtualHost = VirtualHost(server);
+  /// virtualServer.addHost('static.myserver.com').listen(...);
+  /// virtualServer.addHost('cache.myserver.com').listen(...);
+  /// ```
   factory VirtualHost([Stream<HttpRequest> source]) => _VirtualHost(source);
 
   /// Provide another source of [HttpRequest]s in the form of a [Stream].
   void addSource(Stream<HttpRequest> source);
 
-  /// Add a host to the [VirtualHost] instance. The host can be either a specific
-  /// domain (`my.domain.name`) or a wildcard-based domain name
-  /// (`*.domain.name`). The former will only match the specific domain name
-  /// while the latter will match any series of sub-domains.
+  /// Add a host to the [VirtualHost] instance.
+  ///
+  /// The host can be either a specific domain (`my.domain.name`) or a
+  /// wildcard-based domain name (`*.domain.name`). The former will only match
+  /// the specific domain name while the latter will match any series of
+  /// sub-domains.
   ///
   /// If both `my.domain.name` and `*.domain.name` is specified, the most
   /// qualified will take precedence, `my.domain.name` in this case.

--- a/test/http_mock.dart
+++ b/test/http_mock.dart
@@ -1,5 +1,3 @@
-library http_mock;
-
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library utils;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';


### PR DESCRIPTION
- Drop `library` statements where there is no library level doc comment.
- Update code samples in docs to use modern style, use `async`/`await`,
  drop `new`. Remove unnecessary details like `runZoned`.
- Some doc rewrites to follow effective dart recommendations on
  formatting and phrasing.
- Expand some docs that were only repeating signature information so
  that they are more useful.
- Use triple slashes consistently.