### PR TITLE
Disable implicit casts

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,9 @@
 include: package:pedantic/analysis_options.yaml
+analyzer:
+  strong-mode:
+    implicit-casts: false
 linter:
   rules:
-    #- annotate_overrides
     - avoid_empty_else
     - avoid_init_to_null
     - avoid_null_checks_in_equality_operators
@@ -29,7 +31,6 @@ linter:
     - prefer_final_fields
     - prefer_generic_function_type_aliases
     - prefer_is_not_empty
-    #- prefer_single_quotes
     - slash_for_doc_comments
     - test_types_in_equals
     - throw_in_finally

--- a/lib/src/http_body_impl.dart
+++ b/lib/src/http_body_impl.dart
@@ -144,13 +144,13 @@ class HttpBodyHandlerImpl {
       case 'application':
         switch (contentType.subType) {
           case 'json':
-            return asText(utf8)
-                .then((body) => _HttpBody('json', jsonDecode(body.body)));
+            return asText(utf8).then(
+                (body) => _HttpBody('json', jsonDecode(body.body as String)));
 
           case 'x-www-form-urlencoded':
             return asText(ascii).then((body) {
-              var map =
-                  Uri.splitQueryString(body.body, encoding: defaultEncoding);
+              var map = Uri.splitQueryString(body.body as String,
+                  encoding: defaultEncoding);
               var result = {};
               for (var key in map.keys) {
                 result[key] = map[key];


### PR DESCRIPTION
Disable implicit casts in analysis options and fix two cases. Remove the
commented out lint rules that are now enforced by `package:pedantic`.