### PR TITLE
Rename test utilities

### DIFF
--- a/test/http_fakes.dart
+++ b/test/http_fakes.dart
@@ -3,7 +3,7 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
-class MockHttpHeaders implements HttpHeaders {
+class FakeHttpHeaders implements HttpHeaders {
   final Map<String, List<String>> _headers = HashMap<String, List<String>>();
 
   @override
@@ -121,18 +121,18 @@ class MockHttpHeaders implements HttpHeaders {
   }
 }
 
-class MockHttpRequest implements HttpRequest {
+class FakeHttpRequest implements HttpRequest {
   @override
   final Uri uri;
   @override
-  final MockHttpResponse response = MockHttpResponse();
+  final FakeHttpResponse response = FakeHttpResponse();
   @override
-  final HttpHeaders headers = MockHttpHeaders();
+  final HttpHeaders headers = FakeHttpHeaders();
   @override
   final String method = 'GET';
   final bool followRedirects;
 
-  MockHttpRequest(this.uri,
+  FakeHttpRequest(this.uri,
       {this.followRedirects = true, DateTime ifModifiedSince}) {
     if (ifModifiedSince != null) {
       headers.ifModifiedSince = ifModifiedSince;
@@ -146,15 +146,15 @@ class MockHttpRequest implements HttpRequest {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-class MockHttpResponse implements HttpResponse {
+class FakeHttpResponse implements HttpResponse {
   @override
-  final HttpHeaders headers = MockHttpHeaders();
+  final HttpHeaders headers = FakeHttpHeaders();
   final Completer _completer = Completer();
   final List<int> _buffer = <int>[];
   String _reasonPhrase;
   Future _doneFuture;
 
-  MockHttpResponse() {
+  FakeHttpResponse() {
     _doneFuture = _completer.future.whenComplete(() {
       assert(!_isDone);
       _isDone = true;
@@ -212,11 +212,11 @@ class MockHttpResponse implements HttpResponse {
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 
-  String get mockContent => utf8.decode(_buffer);
+  String get fakeContent => utf8.decode(_buffer);
 
-  List<int> get mockContentBinary => _buffer;
+  List<int> get fakeContentBinary => _buffer;
 
-  bool get mockDone => _isDone;
+  bool get fakeDone => _isDone;
 
   // Copied from SDK http_impl.dart @ 845 on 2014-01-05
   // TODO: file an SDK bug to expose this on HttpStatus in some way

--- a/test/virtual_directory_test.dart
+++ b/test/virtual_directory_test.dart
@@ -17,7 +17,7 @@ void _testEncoding(name, expected, [bool create = true]) {
     var virDir = VirtualDirectory(dir.path);
     virDir.allowDirectoryListing = true;
 
-    var result = await getStatusCodeForVirtDir(virDir, '/$name');
+    var result = await statusCodeForVirtDir(virDir, '/$name');
     expect(result, expected);
   });
 }
@@ -27,7 +27,7 @@ void main() {
     testVirtualDir('dir-exists', (dir) {
       var virDir = VirtualDirectory(dir.path);
 
-      return getStatusCodeForVirtDir(virDir, '/').then((result) {
+      return statusCodeForVirtDir(virDir, '/').then((result) {
         expect(result, HttpStatus.notFound);
       });
     });
@@ -35,7 +35,7 @@ void main() {
     testVirtualDir('dir-not-exists', (dir) {
       var virDir = VirtualDirectory(pathos.join('${dir.path}foo'));
 
-      return getStatusCodeForVirtDir(virDir, '/').then((result) {
+      return statusCodeForVirtDir(virDir, '/').then((result) {
         expect(result, HttpStatus.notFound);
       });
     });
@@ -46,7 +46,7 @@ void main() {
       testVirtualDir('file-exists', (dir) {
         File('${dir.path}/file')..createSync();
         var virDir = VirtualDirectory(dir.path);
-        return getStatusCodeForVirtDir(virDir, '/file').then((result) {
+        return statusCodeForVirtDir(virDir, '/file').then((result) {
           expect(result, HttpStatus.ok);
         });
       });
@@ -54,7 +54,7 @@ void main() {
       testVirtualDir('file-not-exists', (dir) {
         var virDir = VirtualDirectory(dir.path);
 
-        return getStatusCodeForVirtDir(virDir, '/file').then((result) {
+        return statusCodeForVirtDir(virDir, '/file').then((result) {
           expect(result, HttpStatus.notFound);
         });
       });
@@ -65,7 +65,7 @@ void main() {
         var dir2 = Directory('${dir.path}/dir')..createSync();
         File('${dir2.path}/file')..createSync();
         var virDir = VirtualDirectory(dir.path);
-        return getStatusCodeForVirtDir(virDir, '/dir/file').then((result) {
+        return statusCodeForVirtDir(virDir, '/dir/file').then((result) {
           expect(result, HttpStatus.ok);
         });
       });
@@ -75,7 +75,7 @@ void main() {
         File('${dir.path}/file')..createSync();
         var virDir = VirtualDirectory(dir.path);
 
-        return getStatusCodeForVirtDir(virDir, '/dir/file').then((result) {
+        return statusCodeForVirtDir(virDir, '/dir/file').then((result) {
           expect(result, HttpStatus.notFound);
         });
       });
@@ -88,7 +88,7 @@ void main() {
         var virDir = VirtualDirectory(dir.path);
         virDir.allowDirectoryListing = true;
 
-        return getAsString(virDir, '/').then((result) {
+        return fetchAsString(virDir, '/').then((result) {
           expect(result, contains('Index of &#47'));
         });
       });
@@ -100,7 +100,7 @@ void main() {
         }
         virDir.allowDirectoryListing = true;
 
-        return getAsString(virDir, '/').then((result) {
+        return fetchAsString(virDir, '/').then((result) {
           expect(result, contains('Index of &#47'));
         });
       });
@@ -110,7 +110,7 @@ void main() {
         Directory('${dir.path}/dir').createSync();
         virDir.allowDirectoryListing = true;
 
-        return getAsString(virDir, '/').then((result) {
+        return fetchAsString(virDir, '/').then((result) {
           expect(result, contains('<a href="dir/">'));
         });
       });
@@ -122,7 +122,7 @@ void main() {
         }
         virDir.allowDirectoryListing = true;
 
-        return getAsString(virDir, '/').then((result) {
+        return fetchAsString(virDir, '/').then((result) {
           expect(result, contains('Index of &#47'));
         });
       });
@@ -132,7 +132,7 @@ void main() {
         Directory('${dir.path}/alert(\'hacked!\');').createSync();
         virDir.allowDirectoryListing = true;
 
-        return getAsString(virDir, '/alert(\'hacked!\');').then((result) {
+        return fetchAsString(virDir, '/alert(\'hacked!\');').then((result) {
           expect(result, contains('&#47;alert(&#39;hacked!&#39;);&#47;'));
         });
       });
@@ -142,7 +142,7 @@ void main() {
         Directory('${dir.path}/æø').createSync();
         virDir.allowDirectoryListing = true;
 
-        return getAsString(virDir, '/').then((result) {
+        return fetchAsString(virDir, '/').then((result) {
           expect(result, contains('æø'));
         });
       });
@@ -151,7 +151,7 @@ void main() {
         var virDir = VirtualDirectory(dir.path);
         virDir.allowDirectoryListing = true;
 
-        return getHeaders(virDir, '/').then((headers) {
+        return fetchHEaders(virDir, '/').then((headers) {
           var contentType = headers.contentType.toString();
           expect(contentType, 'text/html; charset=utf-8');
         });
@@ -164,14 +164,14 @@ void main() {
           virDir.allowDirectoryListing = true;
 
           return Future.wait([
-            getAsString(virDir, '/').then((s) => s.contains('recursive&#47;')),
-            getAsString(virDir, '/').then((s) => !s.contains('../')),
-            getAsString(virDir, '/').then((s) => s.contains('Index of &#47;')),
-            getAsString(virDir, '/recursive')
+            fetchAsString(virDir, '/').then((s) => s.contains('recursive&#47;')),
+            fetchAsString(virDir, '/').then((s) => !s.contains('../')),
+            fetchAsString(virDir, '/').then((s) => s.contains('Index of &#47;')),
+            fetchAsString(virDir, '/recursive')
                 .then((s) => s.contains('recursive&#47;')),
-            getAsString(virDir, '/recursive')
+            fetchAsString(virDir, '/recursive')
                 .then((s) => s.contains('..&#47;')),
-            getAsString(virDir, '/recursive')
+            fetchAsString(virDir, '/recursive')
                 .then((s) => s.contains('Index of &#47;recursive'))
           ]).then((result) {
             expect(result, equals([true, true, true, true, true, true]));
@@ -183,7 +183,7 @@ void main() {
           Directory('${dir.path}/javascript:alert(document);"').createSync();
           virDir.allowDirectoryListing = true;
 
-          return getAsString(virDir, '/').then((result) {
+          return fetchAsString(virDir, '/').then((result) {
             expect(result, contains('javascript%3Aalert(document)%3B%22/'));
           });
         });
@@ -193,7 +193,7 @@ void main() {
           Directory('${dir.path}/<>&"').createSync();
           virDir.allowDirectoryListing = true;
 
-          return getAsString(virDir, '/').then((result) {
+          return fetchAsString(virDir, '/').then((result) {
             expect(result, contains('&lt;&gt;&amp;&quot;&#47;'));
             expect(result, contains('href="%3C%3E%26%22/"'));
           });
@@ -212,7 +212,7 @@ void main() {
           request.response.close();
         };
 
-        return getAsString(virDir, '/').then((result) {
+        return fetchAsString(virDir, '/').then((result) {
           expect(result, 'My handler /');
         });
       });
@@ -227,7 +227,7 @@ void main() {
           return virDir.serveFile(File(indexUri.toFilePath()), request);
         };
 
-        return getAsString(virDir, '/').then((result) {
+        return fetchAsString(virDir, '/').then((result) {
           expect(result, 'index file');
         });
       });
@@ -241,7 +241,7 @@ void main() {
           fail('not expected');
         };
 
-        return getStatusCodeForVirtDir(virDir, '/dir', followRedirects: false)
+        return statusCodeForVirtDir(virDir, '/dir', followRedirects: false)
             .then((result) {
           expect(result, 301);
         });
@@ -258,7 +258,7 @@ void main() {
           var indexUri = Uri.file(dir2.path).resolve('index.html');
           return virDir.serveFile(File(indexUri.toFilePath()), request);
         };
-        return getAsString(virDir, '/dir').then((result) {
+        return fetchAsString(virDir, '/dir').then((result) {
           expect(result, 'index file');
         });
       });
@@ -274,7 +274,7 @@ void main() {
           var indexUri = Uri.file(dir2.path).resolve('index.html');
           virDir.serveFile(File(indexUri.toFilePath()), request);
         };
-        return getAsString(virDir, '/dir/').then((result) {
+        return fetchAsString(virDir, '/dir/').then((result) {
           expect(result, 'index file');
         });
       });
@@ -289,7 +289,7 @@ void main() {
           request.response.close();
         };
 
-        return getStatusCodeForVirtDir(virDir, '/path').then((result) {
+        return statusCodeForVirtDir(virDir, '/path').then((result) {
           expect(result, HttpStatus.ok);
         });
       });
@@ -302,14 +302,14 @@ void main() {
           request.response.close();
         };
 
-        return getStatusCodeForVirtDir(virDir, '/path').then((result) {
+        return statusCodeForVirtDir(virDir, '/path').then((result) {
           expect(result, HttpStatus.ok);
         });
       });
 
       testVirtualDir('not-matching', (dir) {
         var virDir = VirtualDirectory(dir.path, pathPrefix: '/path/');
-        return getStatusCodeForVirtDir(virDir, '/').then((result) {
+        return statusCodeForVirtDir(virDir, '/').then((result) {
           expect(result, HttpStatus.notFound);
         });
       });
@@ -326,7 +326,7 @@ void main() {
           var virDir = VirtualDirectory(dir.path);
           virDir.followLinks = true;
 
-          return getStatusCodeForVirtDir(virDir, '/dir3/file').then((result) {
+          return statusCodeForVirtDir(virDir, '/dir3/file').then((result) {
             expect(result, HttpStatus.ok);
           });
         });
@@ -337,7 +337,7 @@ void main() {
           var virDir = VirtualDirectory(dir.path);
           virDir.followLinks = true;
 
-          return getStatusCodeForVirtDir(virDir, '/dir3/file').then((result) {
+          return statusCodeForVirtDir(virDir, '/dir3/file').then((result) {
             expect(result, HttpStatus.ok);
           });
         });
@@ -349,7 +349,7 @@ void main() {
             var virDir = VirtualDirectory(dir.path);
             virDir.followLinks = true;
 
-            return getStatusCodeForVirtDir(virDir, '/file2').then((result) {
+            return statusCodeForVirtDir(virDir, '/file2').then((result) {
               expect(result, HttpStatus.notFound);
             });
           });
@@ -361,7 +361,7 @@ void main() {
             var virDir = VirtualDirectory(dir2.path);
             virDir.followLinks = true;
 
-            return getStatusCodeForVirtDir(virDir, '/dir3/file').then((result) {
+            return statusCodeForVirtDir(virDir, '/dir3/file').then((result) {
               expect(result, HttpStatus.notFound);
             });
           });
@@ -376,7 +376,7 @@ void main() {
           var virDir = VirtualDirectory(dir.path);
           virDir.followLinks = false;
 
-          return getStatusCodeForVirtDir(virDir, '/dir3/file').then((result) {
+          return statusCodeForVirtDir(virDir, '/dir3/file').then((result) {
             expect(result, HttpStatus.notFound);
           });
         });
@@ -391,7 +391,7 @@ void main() {
             virDir.followLinks = true;
             virDir.jailRoot = false;
 
-            return getStatusCodeForVirtDir(virDir, '/file2').then((result) {
+            return statusCodeForVirtDir(virDir, '/file2').then((result) {
               expect(result, HttpStatus.ok);
             });
           });
@@ -404,7 +404,7 @@ void main() {
             virDir.followLinks = true;
             virDir.jailRoot = false;
 
-            return getStatusCodeForVirtDir(virDir, '/file').then((result) {
+            return statusCodeForVirtDir(virDir, '/file').then((result) {
               expect(result, HttpStatus.ok);
             });
           });
@@ -419,12 +419,12 @@ void main() {
         File('${dir.path}/file')..createSync();
         var virDir = VirtualDirectory(dir.path);
 
-        return getHeaders(virDir, '/file').then((headers) {
+        return fetchHEaders(virDir, '/file').then((headers) {
           expect(headers.value(HttpHeaders.lastModifiedHeader), isNotNull);
           var lastModified =
               HttpDate.parse(headers.value(HttpHeaders.lastModifiedHeader));
 
-          return getStatusCodeForVirtDir(virDir, '/file',
+          return statusCodeForVirtDir(virDir, '/file',
               ifModifiedSince: lastModified);
         }).then((result) {
           expect(result, HttpStatus.notModified);
@@ -435,7 +435,7 @@ void main() {
         File('${dir.path}/file')..createSync();
         var virDir = VirtualDirectory(dir.path);
 
-        return getHeaders(virDir, '/file').then((headers) {
+        return fetchHEaders(virDir, '/file').then((headers) {
           expect(headers.value(HttpHeaders.lastModifiedHeader), isNotNull);
           var lastModified =
               HttpDate.parse(headers.value(HttpHeaders.lastModifiedHeader));
@@ -443,7 +443,7 @@ void main() {
           // Fake file changed by moving date back in time.
           lastModified = lastModified.subtract(const Duration(seconds: 10));
 
-          return getStatusCodeForVirtDir(virDir, '/file',
+          return statusCodeForVirtDir(virDir, '/file',
               ifModifiedSince: lastModified);
         }).then((result) {
           expect(result, HttpStatus.ok);
@@ -458,7 +458,7 @@ void main() {
         File('${dir.path}/file.jpg')..createSync();
         var virDir = VirtualDirectory(dir.path);
 
-        return getHeaders(virDir, '/file.jpg').then((headers) {
+        return fetchHEaders(virDir, '/file.jpg').then((headers) {
           var contentType = headers.contentType.toString();
           expect(contentType, 'image/jpeg');
         });
@@ -469,7 +469,7 @@ void main() {
         file.writeAsBytesSync([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
         var virDir = VirtualDirectory(dir.path);
 
-        return getHeaders(virDir, '/file.jpg').then((headers) {
+        return fetchHEaders(virDir, '/file.jpg').then((headers) {
           var contentType = headers.contentType.toString();
           expect(contentType, 'image/png');
         });
@@ -491,7 +491,7 @@ void main() {
       Future test(int from, int to, [List<int> expected, String contentRange]) {
         expected ??= fileContent.sublist(from, to + 1);
         contentRange ??= 'bytes $from-$to/${fileContent.length}';
-        return getContentAndResponse(virDir, '/file', from: from, to: to)
+        return fetchContentAndResponse(virDir, '/file', from: from, to: to)
             .then(expectAsync1((result) {
           var content = result[0];
           var response = result[1];
@@ -530,7 +530,7 @@ void main() {
               '${fileContent.length - 1}/'
               '${fileContent.length}';
         }
-        return getContentAndResponse(virDir, '/file', from: from)
+        return fetchContentAndResponse(virDir, '/file', from: from)
             .then(expectAsync1((result) {
           var content = result[0];
           var response = result[1];
@@ -563,7 +563,7 @@ void main() {
         contentRange ??= 'bytes ${fileContent.length - to}-'
             '${fileContent.length - 1}/'
             '${fileContent.length}';
-        return getContentAndResponse(virDir, '/file', to: to)
+        return fetchContentAndResponse(virDir, '/file', to: to)
             .then(expectAsync1((result) {
           var content = result[0];
           var response = result[1];
@@ -587,7 +587,7 @@ void main() {
     testVirtualDir('unsatisfiable-range', (dir) {
       prepare(dir);
       Future test(int from, int to) {
-        return getContentAndResponse(virDir, '/file', from: from, to: to)
+        return fetchContentAndResponse(virDir, '/file', from: from, to: to)
             .then(expectAsync1((result) {
           var content = result[0];
           var response = result[1];
@@ -605,7 +605,7 @@ void main() {
     testVirtualDir('invalid-range', (dir) {
       prepare(dir);
       Future test(int from, int to) {
-        return getContentAndResponse(virDir, '/file', from: from, to: to)
+        return fetchContentAndResponse(virDir, '/file', from: from, to: to)
             .then(expectAsync1((result) {
           var content = result[0];
           var response = result[1];
@@ -628,7 +628,7 @@ void main() {
     testVirtualDir('default', (dir) {
       var virDir = VirtualDirectory(pathos.join(dir.path, 'foo'));
 
-      return getAsString(virDir, '/').then((result) {
+      return fetchAsString(virDir, '/').then((result) {
         expect(result, matches(RegExp('404.*Not Found')));
       });
     });
@@ -642,7 +642,7 @@ void main() {
         request.response.close();
       };
 
-      return getAsString(virDir, '/').then((result) {
+      return fetchAsString(virDir, '/').then((result) {
         expect(result, 'my-page 404');
       });
     });
@@ -653,7 +653,7 @@ void main() {
       var virDir = VirtualDirectory(dir.path);
       virDir.allowDirectoryListing = true;
 
-      return getStatusCodeForVirtDir(virDir, '/../').then((result) {
+      return statusCodeForVirtDir(virDir, '/../').then((result) {
         expect(result, HttpStatus.notFound);
       });
     });
@@ -663,7 +663,7 @@ void main() {
       var virDir = VirtualDirectory(dir.path);
       virDir.allowDirectoryListing = true;
 
-      return getStatusCodeForVirtDir(virDir, '/dir/../../').then((result) {
+      return statusCodeForVirtDir(virDir, '/dir/../../').then((result) {
         expect(result, HttpStatus.notFound);
       });
     });
@@ -676,7 +676,7 @@ void main() {
       File('${dir.path}/my file')..createSync();
       var virDir = VirtualDirectory(dir.path);
 
-      return getStatusCodeForVirtDir(virDir, '/my file').then((result) {
+      return statusCodeForVirtDir(virDir, '/my file').then((result) {
         expect(result, HttpStatus.ok);
       });
     });
@@ -685,7 +685,7 @@ void main() {
       File('${dir.path}/my file')..createSync();
       var virDir = VirtualDirectory(dir.path);
 
-      return getStatusCodeForVirtDir(virDir, '/my%20file').then((result) {
+      return statusCodeForVirtDir(virDir, '/my%20file').then((result) {
         expect(result, HttpStatus.notFound);
       });
     });
@@ -697,7 +697,7 @@ void main() {
       var virDir = VirtualDirectory(dir.path);
       virDir.allowDirectoryListing = true;
 
-      return getStatusCodeForVirtDir(virDir, '/a%2fb/c', rawPath: true)
+      return statusCodeForVirtDir(virDir, '/a%2fb/c', rawPath: true)
           .then((result) {
         expect(result, HttpStatus.notFound);
       });
@@ -707,7 +707,7 @@ void main() {
       var virDir = VirtualDirectory(dir.path);
       virDir.allowDirectoryListing = true;
 
-      return getStatusCodeForVirtDir(virDir, '/%00', rawPath: true)
+      return statusCodeForVirtDir(virDir, '/%00', rawPath: true)
           .then((result) {
         expect(result, HttpStatus.notFound);
       });
@@ -736,9 +736,9 @@ void main() {
         return virDir.serveFile(File('${d.path}/file'), request);
       };
 
-      return getAsString(virDir, '/').then((result) {
+      return fetchAsString(virDir, '/').then((result) {
         expect(result, 'file contents');
-        return getHeaders(virDir, '/').then(expectAsync1((headers) {
+        return fetchHEaders(virDir, '/').then(expectAsync1((headers) {
           expect('file contents'.length, headers.contentLength);
         }));
       });

--- a/test/virtual_directory_test.dart
+++ b/test/virtual_directory_test.dart
@@ -164,9 +164,11 @@ void main() {
           virDir.allowDirectoryListing = true;
 
           return Future.wait([
-            fetchAsString(virDir, '/').then((s) => s.contains('recursive&#47;')),
+            fetchAsString(virDir, '/')
+                .then((s) => s.contains('recursive&#47;')),
             fetchAsString(virDir, '/').then((s) => !s.contains('../')),
-            fetchAsString(virDir, '/').then((s) => s.contains('Index of &#47;')),
+            fetchAsString(virDir, '/')
+                .then((s) => s.contains('Index of &#47;')),
             fetchAsString(virDir, '/recursive')
                 .then((s) => s.contains('recursive&#47;')),
             fetchAsString(virDir, '/recursive')
@@ -707,8 +709,7 @@ void main() {
       var virDir = VirtualDirectory(dir.path);
       virDir.allowDirectoryListing = true;
 
-      return statusCodeForVirtDir(virDir, '/%00', rawPath: true)
-          .then((result) {
+      return statusCodeForVirtDir(virDir, '/%00', rawPath: true).then((result) {
         expect(result, HttpStatus.notFound);
       });
     });

--- a/test/virtual_host_test.dart
+++ b/test/virtual_host_test.dart
@@ -17,7 +17,7 @@ void main() {
     expect(
         HttpServer.bind('localhost', 0).then((server) {
           VirtualHost(server);
-          return getStatusCode(server.port, '/').whenComplete(server.close);
+          return fetchStatusCode(server.port, '/').whenComplete(server.close);
         }),
         completion(equals(HttpStatus.forbidden)));
   });
@@ -29,7 +29,7 @@ void main() {
           expect(virHost.unhandled.first.then((request) {
             request.response.close();
           }), completion(isNull));
-          return getStatusCode(server.port, '/').whenComplete(server.close);
+          return fetchStatusCode(server.port, '/').whenComplete(server.close);
         }),
         completion(equals(HttpStatus.ok)));
   });
@@ -43,7 +43,7 @@ void main() {
                 request.response.close();
               }),
               completion(isNull));
-          return getStatusCode(server.port, '/', host: 'my.host.com')
+          return fetchStatusCode(server.port, '/', host: 'my.host.com')
               .whenComplete(server.close);
         }),
         completion(equals(HttpStatus.ok)));
@@ -69,9 +69,9 @@ void main() {
               }),
               completion(isNull));
           return Future.wait([
-            getStatusCode(server.port, '/', host: 'my.host1.com'),
-            getStatusCode(server.port, '/', host: 'my.host2.com'),
-            getStatusCode(server.port, '/', host: 'my.host3.com')
+            fetchStatusCode(server.port, '/', host: 'my.host1.com'),
+            fetchStatusCode(server.port, '/', host: 'my.host2.com'),
+            fetchStatusCode(server.port, '/', host: 'my.host3.com')
           ]).whenComplete(server.close);
         }),
         completion(equals([HttpStatus.ok, HttpStatus.ok, HttpStatus.ok])));
@@ -90,8 +90,8 @@ void main() {
             request.response.close();
           });
           return Future.wait([
-            getStatusCode(servers[0].port, '/', host: 'myhost1.com'),
-            getStatusCode(servers[1].port, '/',
+            fetchStatusCode(servers[0].port, '/', host: 'myhost1.com'),
+            fetchStatusCode(servers[1].port, '/',
                 host: 'myhost2.com', secure: true)
           ]).whenComplete(() => servers.forEach((s) => s.close()));
         }),
@@ -119,9 +119,9 @@ void main() {
                 }),
                 completion(isNull));
             return Future.wait([
-              getStatusCode(server.port, '/', host: 'my1.host.com'),
-              getStatusCode(server.port, '/', host: 'my2.host.com'),
-              getStatusCode(server.port, '/', host: 'my3.host.com')
+              fetchStatusCode(server.port, '/', host: 'my1.host.com'),
+              fetchStatusCode(server.port, '/', host: 'my2.host.com'),
+              fetchStatusCode(server.port, '/', host: 'my3.host.com')
             ]).whenComplete(server.close);
           }),
           completion(equals([HttpStatus.ok, HttpStatus.ok, HttpStatus.ok])));
@@ -147,9 +147,9 @@ void main() {
                 }),
                 completion(isNull));
             return Future.wait([
-              getStatusCode(server.port, '/', host: 'my.host1.com'),
-              getStatusCode(server.port, '/', host: 'my.host2.com'),
-              getStatusCode(server.port, '/', host: 'my.host3.com')
+              fetchStatusCode(server.port, '/', host: 'my.host1.com'),
+              fetchStatusCode(server.port, '/', host: 'my.host2.com'),
+              fetchStatusCode(server.port, '/', host: 'my.host3.com')
             ]).whenComplete(server.close);
           }),
           completion(equals([HttpStatus.ok, HttpStatus.ok, HttpStatus.ok])));
@@ -175,9 +175,9 @@ void main() {
                 }),
                 completion(isNull));
             return Future.wait([
-              getStatusCode(server.port, '/', host: 'my1.host.com'),
-              getStatusCode(server.port, '/', host: 'my2.host.com'),
-              getStatusCode(server.port, '/', host: 'my3.host.com')
+              fetchStatusCode(server.port, '/', host: 'my1.host.com'),
+              fetchStatusCode(server.port, '/', host: 'my2.host.com'),
+              fetchStatusCode(server.port, '/', host: 'my3.host.com')
             ]).whenComplete(server.close);
           }),
           completion(equals([HttpStatus.ok, HttpStatus.ok, HttpStatus.ok])));
@@ -203,9 +203,9 @@ void main() {
                 }),
                 completion(isNull));
             return Future.wait([
-              getStatusCode(server.port, '/', host: 'some.host.dk'),
-              getStatusCode(server.port, '/', host: 'my.host2.com'),
-              getStatusCode(server.port, '/', host: 'long.sub.of.host.com')
+              fetchStatusCode(server.port, '/', host: 'some.host.dk'),
+              fetchStatusCode(server.port, '/', host: 'my.host2.com'),
+              fetchStatusCode(server.port, '/', host: 'long.sub.of.host.com')
             ]).whenComplete(server.close);
           }),
           completion(equals([HttpStatus.ok, HttpStatus.ok, HttpStatus.ok])));


### PR DESCRIPTION
- Rename methods starting with `get`. Where "get" implied an HTTP GET,
  rename to "fetch". Where "get" was a noise word, drop it an use a noun
  named method.
- Rename from "Mock" to "Fake" everywhere. The utilities in these tests
  are not mocks since they don't record interactions.