### PR TITLE
Remove unneeded dart:async import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.0.0
+  - 2.1.0
   - dev
 
 dart_task:

--- a/lib/src/http_multipart_form_data.dart
+++ b/lib/src/http_multipart_form_data.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Library of HTTP server classes.
 homepage: https://www.github.com/dart-lang/http_server
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
   mime: ^0.9.0


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported by dart:core.

Alternatively, if this package has a reason it must continue to support
Dart 2.0, an exception can be made internally for this.